### PR TITLE
Chrome custom tab history fix

### DIFF
--- a/android/src/main/java/com/komoju/android/sdk/KomojuSDK.kt
+++ b/android/src/main/java/com/komoju/android/sdk/KomojuSDK.kt
@@ -39,7 +39,7 @@ object KomojuSDK {
          * Builder class for creating a [Configuration] instance.
          * Offers a flexible way to set optional parameters.
          */
-        class Builder(private var publishableKey: String, private var sessionId: String) {
+        class Builder(private val publishableKey: String, private val sessionId: String) {
             private var language: Language = Language.ENGLISH // Default language is English.
             private var currency: Currency = Currency.JPY // Default currency is Japanese Yen.
             private var isDebugMode: Boolean = false // Debug mode is off by default.
@@ -108,6 +108,7 @@ object KomojuSDK {
      * Property that provides the contract to start the payment process
      * and receive the result (success or failure).
      */
+    @JvmStatic
     val KomojuPaymentResultContract: ActivityResultContract<Configuration, PaymentResult> get() = KomojuStartPaymentForResultContract()
 }
 

--- a/android/src/main/java/com/komoju/android/sdk/utils/OffsiteCustomTabResultContract.kt
+++ b/android/src/main/java/com/komoju/android/sdk/utils/OffsiteCustomTabResultContract.kt
@@ -2,6 +2,7 @@ package com.komoju.android.sdk.utils
 
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NO_HISTORY
 import android.graphics.Color
 import android.net.Uri
 import androidx.activity.result.contract.ActivityResultContract
@@ -29,6 +30,7 @@ internal class OffsiteCustomTabResultContract : ActivityResultContract<String, I
             .setToolbarCornerRadiusDp(10)
         val customTabsIntent = builder.build().intent
         customTabsIntent.setData(Uri.parse(input))
+        customTabsIntent.flags += FLAG_ACTIVITY_NO_HISTORY
         return customTabsIntent
     }
 


### PR DESCRIPTION
Make sure that the Chrome custom tab have no history left after capturing the deeplink